### PR TITLE
Stop interpreting MONGOLIAN VOWEL SEPARATOR as white space character …

### DIFF
--- a/Njsast/Reader/CharCode.cs
+++ b/Njsast/Reader/CharCode.cs
@@ -1,0 +1,21 @@
+namespace Njsast.Reader
+{
+    public static class CharCode
+    {
+        public const int BackSpace = 8;
+        public const int CharacterTabulation = 9;
+        public const int LineFeed = 10;
+        public const int LineTabulation = 11;
+        public const int FormFeed = 12;
+        public const int CarriageReturn = 13;
+        public const int ShiftOut = 14;
+        public const int Space = 32;
+        public const int Asterisk = 42;
+        public const int Slash = 47;
+        public const int BackSlash = 92;
+        public const int NoBreakSpace = 160;
+        public const int OghamSpaceMark = 5760;
+        public const int LineSeparator = 8232;
+        public const int ParagraphSeparator = 8233;
+    }
+}

--- a/Njsast/Reader/Tokenise.cs
+++ b/Njsast/Reader/Tokenise.cs
@@ -67,7 +67,7 @@ namespace Njsast.Reader
         {
             // Identifier or keyword. '\uXXXX' sequences are allowed in
             // identifiers, so '\' also dispatches to that.
-            if (IsIdentifierStart(code, Options.EcmaVersion >= 6) || code == 92 /* '\' */)
+            if (IsIdentifierStart(code, Options.EcmaVersion >= 6) || code == CharCode.BackSlash /* '\' */)
             {
                 ReadWord();
                 return;
@@ -127,26 +127,26 @@ namespace Njsast.Reader
                 var ch = (int)_input[_pos.Index];
                 switch (ch)
                 {
-                    case 32:
-                    case 160: // ' '
+                    case CharCode.Space:
+                    case CharCode.NoBreakSpace:
                         _pos = _pos.Increment(1);
                         break;
-                    case 13:
+                    case CharCode.CarriageReturn:
                         if (_pos.Index + 1 < _input.Length && _input[_pos.Index + 1] == 10)
                             _pos = _pos.Increment(1);
-                        goto case 10;
-                    case 10:
-                    case 8232:
-                    case 8233:
+                        goto case CharCode.LineFeed;
+                    case CharCode.LineFeed:
+                    case CharCode.LineSeparator:
+                    case CharCode.ParagraphSeparator:
                         _pos = new Position(_pos.Line + 1, 0, _pos.Index + 1);
                         break;
-                    case 47: // '/'
+                    case CharCode.Slash:
                         switch ((int)_input.Get(_pos.Index + 1))
                         {
-                            case 42: // '*'
+                            case CharCode.Asterisk:
                                 SkipBlockComment();
                                 break;
-                            case 47:
+                            case CharCode.Slash:
                                 SkipLineComment(2);
                                 break;
                             default:
@@ -154,7 +154,7 @@ namespace Njsast.Reader
                         }
                         break;
                     default:
-                        if (ch > 8 && ch < 14 || ch >= 5760 && NonAsciIwhitespace.IsMatch(((char)ch).ToString()))
+                        if (ch > CharCode.BackSpace && ch < CharCode.ShiftOut || ch >= CharCode.OghamSpaceMark && NonAsciIwhitespace.IsMatch(((char)ch).ToString()))
                         {
                             _pos = _pos.Increment(1);
                             break;

--- a/Njsast/Reader/Whitespace.cs
+++ b/Njsast/Reader/Whitespace.cs
@@ -4,13 +4,39 @@ namespace Njsast.Reader
 {
     public sealed partial class Parser
     {
+        /**
+         * \u2028 LINE SEPARATOR
+         * \u2029 PARAGRAPH SEPARATOR
+         */
         static readonly Regex LineBreak = new Regex("\r\n?|\n|\u2028|\u2029");
-        static readonly Regex NonAsciIwhitespace = new Regex(@"[\u1680\u180e\u2000-\u200a\u202f\u205f\u3000\ufeff]");
+        /**
+         * \u1680 OGHAM SPACE MARK
+         * \u2000 EN QUAD
+         * \u2001 EM QUAD
+         * \u2002 EN SPACE
+         * \u2003 EM SPACE
+         * \u2004 THREE-PER-EM SPACE
+         * \u2005 FOUR-PER-EM SPACE
+         * \u2006 SIX-PER-EM SPACE
+         * \u2007 FIGURE SPACE
+         * \u2008 PUNCTUATION SPACE
+         * \u2009 THIN SPACE
+         * \u200A HAIR SPACE
+         * \u202F NARROW NO-BREAK SPACE
+         * \u205F MEDIUM MATHEMATICAL SPACE
+         * \u3000 IDEOGRAPHIC SPACE
+         * \uFEFF ZERO WIDTH NO-BREAK SPACE
+         */
+        // Note \u180e MONGOLIAN VOWEL SEPARATOR Is no longer classified as space character (Unicode >= 6.3.0) =>
+        // https://en.wikipedia.org/wiki/Whitespace_character
+        // and is not in "Zs" unicode category => https://www.compart.com/en/unicode/category/Zs 
+        // https://www.ecma-international.org/ecma-262/10.0/index.html#table-32
+        static readonly Regex NonAsciIwhitespace = new Regex(@"[\u1680\u2000-\u200a\u202f\u205f\u3000\ufeff]");
         static readonly Regex SkipWhiteSpace = new Regex(@"(?:\s|\/\/.*|\/\*.*?\*\/)*");
 
         static bool IsNewLine(char code)
         {
-            return code == 10 || code == 13 || code == 0x2028 || code == 0x2029;
+            return code == CharCode.LineFeed || code == CharCode.CarriageReturn || code == CharCode.LineSeparator || code == CharCode.ParagraphSeparator;
         }
     }
 }

--- a/Test/Reader/ParserTest.cs
+++ b/Test/Reader/ParserTest.cs
@@ -1,3 +1,4 @@
+using System;
 using Njsast.AstDump;
 using Njsast.Output;
 using Njsast.Reader;
@@ -9,6 +10,10 @@ namespace Test.Reader
 {
     public class ParserTest
     {
+        private const string SimpleVarStatement = "var a = 1";
+        private const string SimpleVarStatementAst = "Toplevel 1:1 - 1:10\n  Var 1:1 - 1:10\n    VarDef 1:5 - 1:10\n      SymbolVar 1:5 - 1:6\n        Name: a\n      Number 1:9 - 1:10\n        Value: 1\n        Literal: 1\n";
+        private const string SimpleVarStatementMultilineAst = "Toplevel 1:1 - 4:2\n  Var 1:1 - 4:2\n    VarDef 2:1 - 4:2\n      SymbolVar 2:1 - 2:2\n        Name: a\n      Number 4:1 - 4:2\n        Value: 1\n        Literal: 1\n";
+
         [Theory]
         [ParserTestDataProvider("Input/Parser")]
         public void ParserShouldProduceExpectedResultOrSyntaxError(ParserTestData testData)
@@ -52,6 +57,60 @@ namespace Test.Reader
             Assert.Equal(testData.ExpectedMinJsMap, outMinJsMap);
             Assert.Equal(testData.ExpectedNiceJs, outNiceJs);
             Assert.Equal(testData.ExpectedNiceJsMap, outNiceJsMap);
+        }
+        
+        [Theory]
+        // More info about white space characters https://en.wikipedia.org/wiki/Whitespace_character
+        [InlineData('\u0009' /*CHARACTER TABULATION*/, SimpleVarStatementAst)]
+        [InlineData('\u000b' /*LINE TABULATION*/, SimpleVarStatementAst)]
+        [InlineData('\u000c' /*FORM FEED*/, SimpleVarStatementAst)]
+        [InlineData('\u0020' /*SPACE*/, SimpleVarStatementAst)]
+        [InlineData('\u00a0' /*NO-BREAK SPACE*/, SimpleVarStatementAst)]
+        [InlineData('\ufeff' /*ZERO WIDTH NO-BREAK SPACE*/, SimpleVarStatementAst)]
+        [InlineData('\u1680' /*OGHAM SPACE MARK*/, SimpleVarStatementAst)]
+        [InlineData('\u2000' /*EN QUAD*/, SimpleVarStatementAst)]
+        [InlineData('\u2001' /*EM QUAD*/, SimpleVarStatementAst)]
+        [InlineData('\u2002' /*EN SPACE*/, SimpleVarStatementAst)]
+        [InlineData('\u2003' /*EM SPACE*/, SimpleVarStatementAst)]
+        [InlineData('\u2004' /*THREE-PER-EM SPACE*/, SimpleVarStatementAst)]
+        [InlineData('\u2005' /*FOUR-PER-EM SPACE*/, SimpleVarStatementAst)]
+        [InlineData('\u2006' /*SIX-PER-EM SPACE*/, SimpleVarStatementAst)]
+        [InlineData('\u2007' /*FIGURE SPACE*/, SimpleVarStatementAst)]
+        [InlineData('\u2008' /*PUNCTUATION SPACE*/, SimpleVarStatementAst)]
+        [InlineData('\u2009' /*THIN SPACE*/, SimpleVarStatementAst)]
+        [InlineData('\u200A' /*HAIR SPACE*/, SimpleVarStatementAst)]
+        [InlineData('\u202F' /*NARROW NO-BREAK SPACE*/, SimpleVarStatementAst)]
+        [InlineData('\u205F' /*MEDIUM MATHEMATICAL SPACE*/, SimpleVarStatementAst)]
+        [InlineData('\u3000' /*IDEOGRAPHIC SPACE*/, SimpleVarStatementAst)]
+        [InlineData('\u180e' /*MONGOLIAN VOWEL SEPARATOR*/, "Unexpected character '\u180e' (1:4)")]
+        [InlineData('\u200b' /*ZERO WIDTH SPACE*/, "Unexpected character '\u200b' (1:4)")]
+        [InlineData('\u200c' /*ZERO WIDTH NON-JOINER*/, "Unexpected character '\u200c' (1:8)")]
+        [InlineData('\u200d' /*ZERO WIDTH JOINER*/, "Unexpected character '\u200d' (1:8)")]
+        [InlineData('\u2060' /*WORD JOINER*/, "Unexpected character '\u2060' (1:4)")]
+        [InlineData('\u0085' /*NEXT LINE*/, "Unexpected character '\u0085' (1:4)")]
+        [InlineData('\u000a' /*LINE FEED*/, SimpleVarStatementMultilineAst)]
+        [InlineData('\u000d' /*CARRIAGE RETURN*/, SimpleVarStatementMultilineAst)]
+        [InlineData('\u2028' /*LINE SEPARATOR*/, SimpleVarStatementMultilineAst)]
+        [InlineData('\u2029' /*PARAGRAPH SEPARATOR*/, SimpleVarStatementMultilineAst)]
+        public void ParserShouldSkipAllowedUnicodeWhiteSpaceCharactersOrProduceSyntaxError(char whiteSpaceChar, string expectedAst)
+        {
+            var input = SimpleVarStatement.Replace(' ', whiteSpaceChar);
+            string outAst;
+            try
+            {
+                var parser = new Parser(new Options(), input);
+                var toplevel = parser.Parse();
+                var strSink = new StringLineSink();
+                var dumper = new DumpAst(new AstDumpWriter(strSink));
+                dumper.Walk(toplevel);
+                outAst = strSink.ToString();
+            }
+            catch (SyntaxError e)
+            {
+                outAst = e.Message;
+            }
+            
+            Assert.Equal(expectedAst, outAst);
         }
     }
 }


### PR DESCRIPTION
…(to behave same as current JS Engines and spec)
[https://codeblog.jonskeet.uk/2014/12/01/when-is-an-identifier-not-an-identifier-attack-of-the-mongolian-vowel-separator/](https://codeblog.jonskeet.uk/2014/12/01/when-is-an-identifier-not-an-identifier-attack-of-the-mongolian-vowel-separator/)

Refactor some char codes to static class constants to improvement readability of code
Added test which check if parser correctly recognize allowed white space characters